### PR TITLE
Shorter CSS selectors

### DIFF
--- a/code/js/tools/CSSGenerator.js
+++ b/code/js/tools/CSSGenerator.js
@@ -1,4 +1,4 @@
-function CSSGenerator(domElement) {
+function CSSGenerator(domElement, doc) {
 
     function getNthOfTypeIndex(domElement) {
         if (domElement.parentNode) {
@@ -30,13 +30,26 @@ function CSSGenerator(domElement) {
         return '#' + element.id;
     }
 
+    function getDocument() {
+        if (doc) {
+            return doc;
+        }
+        return document;
+    }
+
     function handleElementWithName(elements, element) {
-        var inputSelector = element.lowerCasedTagName + '[name=\'' + element.name + '\']';
-        var siblingsAlsoMatchInputSelector = element.parentNode.querySelectorAll(inputSelector).length > 1;
+        var nameSelector = element.lowerCasedTagName + '[name=\'' + element.name + '\']';
+
+        var hitsCount = getDocument().querySelectorAll(nameSelector).length;
+        if (hitsCount === 1) {
+            return nameSelector;
+        }
+
+        var siblingsAlsoMatchInputSelector = element.parentNode.querySelectorAll(nameSelector).length > 1;
         if (siblingsAlsoMatchInputSelector) {
             return generatePath(elements) + ' > ' + getNthOfTypeTagSelectorWithName(element);
         } else {
-            return generatePath(elements) + ' > ' + inputSelector;
+            return generatePath(elements) + ' > ' + nameSelector;
         }
     }
 
@@ -66,7 +79,7 @@ function CSSGenerator(domElement) {
 
     function handleCssClassSelector(elements, element) {
         var selectorByClasses = '.' + element.cssClasses.join('.');
-        var hitsCount = document.querySelectorAll(selectorByClasses).length;
+        var hitsCount = getDocument().querySelectorAll(selectorByClasses).length;
         if (hitsCount === 1) {
             return selectorByClasses;
         } else {

--- a/code/spec/CSSGeneratorSpec.js
+++ b/code/spec/CSSGeneratorSpec.js
@@ -1,83 +1,83 @@
 describe('CSSGenerator', function () {
 
     describe('DOM with IDs', function () {
-        var targetElement;
+        var createdDom;
 
         it("finds element with id", function () {
-            targetElement = createDocWithTargetElementThatHasId('<div id="target-element"></div>');
-            expect(CSSGenerator(targetElement)).toEqual('#target-element');
+            createdDom = createDocWithTargetElementThatHasId('<div id="target-element"></div>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('#target-element');
         });
     });
 
     describe('DOM with classses', function () {
-        var targetElement;
+        var createdDom;
 
         it("finds element with class that has siblings of same type", function () {
-            targetElement = createDocWithTargetElement('<div id="target-element" class="element-class"></div><div class="another-element-class"></div>');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > .element-class');
+            createdDom = createDocWithTargetElement('<div id="target-element" class="element-class"></div><div class="another-element-class"></div>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('.element-class');
         });
 
         it("finds element with class that has no siblings of same type", function () {
-            targetElement = createDocWithTargetElement('<div id="target-element" class="element-class"></div><li class="another-element-class"></li>');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > .element-class');
+            createdDom = createDocWithTargetElement('<div id="target-element" class="element-class"></div><li class="another-element-class"></li>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('.element-class');
         });
 
         it("finds first element with class that siblings also have", function () {
-            targetElement = createDocWithTargetElement('<div id="target-element" class="element-class"></div><div class="element-class"></div>');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > div:nth-of-type(1)');
+            createdDom = createDocWithTargetElement('<div id="target-element" class="element-class"></div><div class="element-class"></div>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('html > body > div:nth-of-type(1)');
         });
 
         it("finds second element with class that siblings also have", function () {
-            targetElement = createDocWithTargetElement('<div class="element-class"></div><div id="target-element" class="element-class"></div>');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > div:nth-of-type(2)');
+            createdDom = createDocWithTargetElement('<div class="element-class"></div><div id="target-element" class="element-class"></div>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('html > body > div:nth-of-type(2)');
         });
 
         it("finds element with class that has extra spaces", function () {
-            targetElement = createDocWithTargetElement('<div id="target-element" class=" element-class "></div>');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > .element-class');
+            createdDom = createDocWithTargetElement('<div id="target-element" class=" element-class "></div>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('.element-class');
         });
     });
 
     describe('DOM with name attribute', function () {
-        var targetElement;
+        var createdDom;
 
         it("finds input element that has unique name", function () {
-            targetElement = createDocWithTargetElement('<input name="second-input-name" /><input id="target-element" name="input-name" />');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > input[name=\'input-name\']');
+            createdDom = createDocWithTargetElement('<div id="div-id"><div><button id="target-element" name="button-name">Button</button></div></div>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('button[name=\'button-name\']');
         });
 
         it("finds input element that has nonunique name", function () {
-            targetElement = createDocWithTargetElement('<input name="input-name" /><input id="target-element" name="input-name" />');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > input[name=\'input-name\']:nth-of-type(2)');
+            createdDom = createDocWithTargetElement('<input name="input-name" /><input id="target-element" name="input-name" />');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('html > body > input[name=\'input-name\']:nth-of-type(2)');
         });
 
         it("finds button element that has unique name", function () {
-            targetElement = createDocWithTargetElement('<button id="target-element" name="button-name">Button</button>');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > button[name=\'button-name\']');
+            createdDom = createDocWithTargetElement('<button id="target-element" name="button-name">Button</button>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('button[name=\'button-name\']');
         });
 
         it("finds button element that has nonunique name", function () {
-            targetElement = createDocWithTargetElement('<button name="button-name">Button 1</button><button id="target-element" name="button-name">Button 2</button>');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > button[name=\'button-name\']:nth-of-type(2)');
+            createdDom = createDocWithTargetElement('<button name="button-name">Button 1</button><button id="target-element" name="button-name">Button 2</button>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('html > body > button[name=\'button-name\']:nth-of-type(2)');
         });
 
     });
 
     describe('DOM with siblings of same type', function () {
-        var targetElement;
+        var createdDom;
 
         it("finds element that has siblings of same type", function () {
-            targetElement = createDocWithTargetElement('<div id="target-element"></div><div></div><div></div>');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > div:nth-of-type(1)');
+            createdDom = createDocWithTargetElement('<div id="target-element"></div><div></div><div></div>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('html > body > div:nth-of-type(1)');
         });
     });
 
     describe('DOM with no siblings', function () {
-        var targetElement;
+        var createdDom;
 
         it("finds element that has no siblings", function () {
-            targetElement = createDocWithTargetElement('<div id="target-element"></div>');
-            expect(CSSGenerator(targetElement)).toEqual('html > body > div');
+            createdDom = createDocWithTargetElement('<div id="target-element"></div>');
+            expect(CSSGenerator(createdDom.targetElement, createdDom.doc)).toEqual('html > body > div');
         });
     });
 

--- a/code/spec/XPathGeneratorSpec.js
+++ b/code/spec/XPathGeneratorSpec.js
@@ -1,64 +1,68 @@
-describe('XPathGenerator', function() {
+describe('XPathGenerator', function () {
 
-	describe('DOM with IDs', function() {
+    describe('DOM with IDs', function () {
+        var createdDom;
 
-		it("finds element with id", function() {
-			targetElement = createDocWithTargetElementThatHasId('<div id="target-element"></div>');
-			expect(XPathGenerator(targetElement)).toEqual('//*[@id=\'target-element\']');
-		});
-	});
+        it("finds element with id", function () {
+            createdDom = createDocWithTargetElementThatHasId('<div id="target-element"></div>');
+            expect(XPathGenerator(createdDom.targetElement, createdDom.doc)).toEqual('//*[@id=\'target-element\']');
+        });
+    });
 
-	describe('DOM with classses', function() {
-		var targetElement;
+    describe('DOM with classses', function () {
+        var createdDom;
 
-		it("finds element with class that has siblings of same type", function() {
-			targetElement = createDocWithTargetElement('<div id="target-element" class="element-class"></div><div class="another-element-class"></div>');
-			expect(XPathGenerator(targetElement)).toEqual('/html/body/div[1]');
-		});
+        it("finds element with class that has siblings of same type", function () {
+            createdDom = createDocWithTargetElement('<div id="target-element" class="element-class"></div><div class="another-element-class"></div>');
+            expect(XPathGenerator(createdDom.targetElement, createdDom.doc)).toEqual('/html/body/div[1]');
+        });
 
-		it("finds element with class that has no siblings of same type", function() {
-			targetElement = createDocWithTargetElement('<div id="target-element" class="element-class"></div><li class="another-element-class"></li>');
-			expect(XPathGenerator(targetElement)).toEqual('/html/body/div');
-		});
+        it("finds element with class that has no siblings of same type", function () {
+            createdDom = createDocWithTargetElement('<div id="target-element" class="element-class"></div><li class="another-element-class"></li>');
+            expect(XPathGenerator(createdDom.targetElement, createdDom.doc)).toEqual('/html/body/div');
+        });
 
-		it("finds first element with class that siblings also have", function() {
-			targetElement = createDocWithTargetElement('<div id="target-element" class="element-class"></div><div class="element-class"></div>');
-			expect(XPathGenerator(targetElement)).toEqual('/html/body/div[1]');
-		});
+        it("finds first element with class that siblings also have", function () {
+            createdDom = createDocWithTargetElement('<div id="target-element" class="element-class"></div><div class="element-class"></div>');
+            expect(XPathGenerator(createdDom.targetElement, createdDom.doc)).toEqual('/html/body/div[1]');
+        });
 
-		it("finds second element with class that siblings also have", function() {
-			targetElement = createDocWithTargetElement('<div class="element-class"></div><div id="target-element" class="element-class"></div>');
-			expect(XPathGenerator(targetElement)).toEqual('/html/body/div[2]');
-		});
-	});
+        it("finds second element with class that siblings also have", function () {
+            createdDom = createDocWithTargetElement('<div class="element-class"></div><div id="target-element" class="element-class"></div>');
+            expect(XPathGenerator(createdDom.targetElement, createdDom.doc)).toEqual('/html/body/div[2]');
+        });
+    });
 
-	describe('DOM with inputs', function() {
+    describe('DOM with inputs', function () {
+        var createdDom;
 
-		it("finds element with input that has unique name", function() {
-			targetElement = createDocWithTargetElement('<input id="target-element" name="input-name" />');
-			expect(XPathGenerator(targetElement)).toEqual('/html/body/input');
-		});
+        it("finds element with input that has unique name", function () {
+            createdDom = createDocWithTargetElement('<input id="target-element" name="input-name" />');
+            expect(XPathGenerator(createdDom.targetElement, createdDom.doc)).toEqual('/html/body/input');
+        });
 
-		it("finds element with input that has nonunique name", function() {
-			targetElement = createDocWithTargetElement('<input name="input-name" /><input id="target-element" name="input-name" />');
-			expect(XPathGenerator(targetElement)).toEqual('/html/body/input[2]');
-		});
-	});
+        it("finds element with input that has nonunique name", function () {
+            createdDom = createDocWithTargetElement('<input name="input-name" /><input id="target-element" name="input-name" />');
+            expect(XPathGenerator(createdDom.targetElement, createdDom.doc)).toEqual('/html/body/input[2]');
+        });
+    });
 
-	describe('DOM with siblings of same type', function() {
+    describe('DOM with siblings of same type', function () {
+        var createdDom;
 
-		it("finds element that has siblings of same type", function() {
-			targetElement = createDocWithTargetElement('<div id="target-element"></div><div></div><div></div>');
-			expect(XPathGenerator(targetElement)).toEqual('/html/body/div[1]');
-		});
-	});
+        it("finds element that has siblings of same type", function () {
+            createdDom = createDocWithTargetElement('<div id="target-element"></div><div></div><div></div>');
+            expect(XPathGenerator(createdDom.targetElement, createdDom.doc)).toEqual('/html/body/div[1]');
+        });
+    });
 
-	describe('DOM with no siblings', function() {
+    describe('DOM with no siblings', function () {
+        var createdDom;
 
-		it("finds element that has no siblings", function() {
-			targetElement = createDocWithTargetElement('<div id="target-element"></div>');
-			expect(XPathGenerator(targetElement)).toEqual('/html/body/div');
-		});
-	});
+        it("finds element that has no siblings", function () {
+            createdDom = createDocWithTargetElement('<div id="target-element"></div>');
+            expect(XPathGenerator(createdDom.targetElement, createdDom.doc)).toEqual('/html/body/div');
+        });
+    });
 
 });

--- a/code/spec/fixture/fixture.js
+++ b/code/spec/fixture/fixture.js
@@ -1,19 +1,19 @@
 function createDocWithTargetElementThatHasId(html) {
-	var doc, targetElement;
+    var doc;
 
-	doc = document.implementation.createHTMLDocument('Document');
-	doc.body.innerHTML = html;
+    doc = document.implementation.createHTMLDocument('Document');
+    doc.body.innerHTML = html;
 
-	return doc.getElementById('target-element');
+    return {targetElement: doc.getElementById('target-element'), doc: doc};
 }
 
 function createDocWithTargetElement(html) {
-	var doc, targetElement;
-	
-	doc = document.implementation.createHTMLDocument('Document');
-	doc.body.innerHTML = html;
-	targetElement = doc.getElementById('target-element');
-	targetElement.removeAttribute('id');
-	
-	return targetElement;
+    var doc, targetElement;
+
+    doc = document.implementation.createHTMLDocument('Document');
+    doc.body.innerHTML = html;
+    targetElement = doc.getElementById('target-element');
+    targetElement.removeAttribute('id');
+
+    return {targetElement: targetElement, doc: doc};
 }


### PR DESCRIPTION
If element has a name attribute, check the uniqueness of that and
use it as the only selector if it is unique.

Also fixed tests to use a different document (it was using Jasmine's HTML
DOM which was wrong).

Fixes issue #4